### PR TITLE
fixed issue where clicking inbetween buttons caused an error

### DIFF
--- a/Calculator/app.js
+++ b/Calculator/app.js
@@ -126,7 +126,10 @@ $eq.on('click',(event)=>{
 })
 
 $('.buttonrow').on('click',(event) =>{
+	$(event.target)[0].className == 'buttonrow' ? console.log('not a clickable area') :
 	$('#screen').text($('#screen').text() + $(event.target).text());
+	console.log($(event.target))
+	console.log($(event.target)[0].className)
 	console.log($('#screen').text);
 })
 


### PR DESCRIPTION
7 8 9 / 4 5 6 X 1 2 3 - 0 . + = was loading into the calculator if areas around the buttons were clicked. This was resolved by preventing the function from running if that area was clicked.
